### PR TITLE
Various tweaks for compatibility with react-native-web

### DIFF
--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Text } from 'react-native';
+import { Animated } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Affix extends PureComponent {
 
   static propTypes = {
     numberOfLines: PropTypes.number,
-    style: Text.propTypes.style,
+    style: PropTypes.any,
 
     color: PropTypes.string.isRequired,
     fontSize: PropTypes.number.isRequired,

--- a/src/components/counter/index.js
+++ b/src/components/counter/index.js
@@ -12,7 +12,7 @@ export default class Counter extends PureComponent {
     baseColor: PropTypes.string.isRequired,
     errorColor: PropTypes.string.isRequired,
 
-    style: Text.propTypes.style,
+    style: PropTypes.any,
   };
 
   render() {

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -2,12 +2,10 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import {
   View,
-  Text,
   TextInput,
   Animated,
   StyleSheet,
   Platform,
-  ViewPropTypes,
 } from 'react-native';
 
 import Line from '../line';
@@ -66,8 +64,6 @@ export default class TextField extends PureComponent {
   };
 
   static propTypes = {
-    ...TextInput.propTypes,
-
     animationDuration: PropTypes.number,
 
     fontSize: PropTypes.number,
@@ -84,9 +80,9 @@ export default class TextField extends PureComponent {
 
     labelOffset: Label.propTypes.offset,
 
-    labelTextStyle: Text.propTypes.style,
-    titleTextStyle: Text.propTypes.style,
-    affixTextStyle: Text.propTypes.style,
+    labelTextStyle: PropTypes.any,
+    titleTextStyle: PropTypes.any,
+    affixTextStyle: PropTypes.any,
 
     tintColor: PropTypes.string,
     textColor: PropTypes.string,
@@ -117,8 +113,8 @@ export default class TextField extends PureComponent {
     prefix: PropTypes.string,
     suffix: PropTypes.string,
 
-    containerStyle: (ViewPropTypes || View.propTypes).style,
-    inputContainerStyle: (ViewPropTypes || View.propTypes).style,
+    containerStyle: PropTypes.any,
+    inputContainerStyle: PropTypes.any,
   };
 
   static inputContainerStyle = styles.inputContainer;
@@ -453,15 +449,9 @@ export default class TextField extends PureComponent {
   inputProps() {
     let store = {};
 
-    for (let key in TextInput.propTypes) {
-      if ('defaultValue' === key) {
-        continue;
-      }
-
-      if (key in this.props) {
-        store[key] = this.props[key];
-      }
-    }
+    Object.keys(this.props).forEach((key) => {
+      store[key] = this.props[key];
+    });
 
     return store;
   }

--- a/src/components/helper/index.js
+++ b/src/components/helper/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Text } from 'react-native';
+import { Animated } from 'react-native';
 
 import styles from './styles';
 
@@ -11,7 +11,7 @@ export default class Helper extends PureComponent {
 
     disabled: PropTypes.bool,
 
-    style: Text.propTypes.style,
+    style: PropTypes.any,
 
     baseColor: PropTypes.string,
     errorColor: PropTypes.string,

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Text } from 'react-native';
+import { Animated } from 'react-native';
 
 import styles from './styles';
 
@@ -43,7 +43,7 @@ export default class Label extends PureComponent {
       y1: PropTypes.number,
     }),
 
-    style: Text.propTypes.style,
+    style: PropTypes.any,
     label: PropTypes.string,
   };
 
@@ -104,7 +104,7 @@ export default class Label extends PureComponent {
       }, {
         translateX: labelAnimation.interpolate({
           inputRange: [0, 1],
-          outputRange: [x0, x1],
+          outputRange: [x0, x1 - fontSize],
         }),
       }],
     };

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated } from 'react-native';
+import { Platform, Animated } from 'react-native';
 
 import styles from './styles';
 
@@ -104,7 +104,7 @@ export default class Label extends PureComponent {
       }, {
         translateX: labelAnimation.interpolate({
           inputRange: [0, 1],
-          outputRange: [x0, x1 - fontSize],
+          outputRange: [x0, Platform.select({default: x1, web: x1 - fontSize})],
         }),
       }],
     };

--- a/src/components/label/styles.js
+++ b/src/components/label/styles.js
@@ -4,9 +4,6 @@ export default StyleSheet.create({
   container: {
     position: 'absolute',
     top: 0,
-    left: '-100%',
-    width: '200%',
-    paddingLeft: '50%',
   },
 
   text: {

--- a/src/components/label/styles.js
+++ b/src/components/label/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 
 export default StyleSheet.create({
   container: {

--- a/src/components/label/styles.js
+++ b/src/components/label/styles.js
@@ -2,6 +2,11 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   container: {
+    ...Platform.select({default: {
+      left: '-100%',
+      width: '200%',
+      paddingLeft: '50%'
+    }, web: {}}),
     position: 'absolute',
     top: 0,
   },


### PR DESCRIPTION
## Problem
The component won't render on the web because of the references to components' `propTypes` from `react-native`. When aliasing `react-native-web` to `react-native`, the attempt to reference `propTypes` will fail because `react-native-web` doesn't export `propTypes` from its equivalent components.

## Solution
- Changes any reference to `react-native` component `propTypes` to `PropTypes.any`.
  - I believe `propTypes` are deprecated in `react-native`: https://github.com/react-native-community/discussions-and-proposals/issues/29

### Other changes
- Always disable the native driver for animations on the web
- Change the calculation on the x-axis of the `Label` when the text field is focussed (the previous positioning styles in combination with the css translation didn't work on the web). The new solution produces the same result on iOS and the web